### PR TITLE
improve nav-tabs

### DIFF
--- a/src/v2/scss/components/_nav-tabs.scss
+++ b/src/v2/scss/components/_nav-tabs.scss
@@ -7,11 +7,13 @@
   overflow-x: scroll;
   overflow-y: hidden;
   @include media-breakpoint-up(sm) {
+    flex-wrap: wrap;
+    overflow-x: visible;
     padding: 0;
   }
 
   .nav-item {
-    margin-left: -$border-width;
+    margin-right: -$border-width;
     &:first-child {
       margin-left: 0;
       border-top-left-radius: $border-radius;

--- a/templates/v2/components/nav-tabs.jinja2
+++ b/templates/v2/components/nav-tabs.jinja2
@@ -47,8 +47,9 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-lg-3">
-                <h3>Scrollable</h3>
+            <div class="col-lg-4">
+                <h3>Overflow</h3>
+                <p>Wrap for desktop, scroll for mobile</p>
                 <ul class="ui nav-tabs">
                     <li class="nav-item">
                         <a class="nav-link active" href="#">Санкт-Петербург</a>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8073736/61789866-71064900-ae1e-11e9-993b-fb62c373b8df.png)
можно считать что на мобилках табы чаще всего не будут помещаться и добавлять отступ под скролл только на мобилки. margin-bottom решил оставить т.к. это минимально необходимое расстояние от компонента.