### PR TITLE
fix: footer position for body with scrollspy

### DIFF
--- a/src/v2/scss/layouts/_base.scss
+++ b/src/v2/scss/layouts/_base.scss
@@ -17,9 +17,9 @@ html {
 }
 
 body {
-  margin-bottom: $footer-mobile-height;
+  padding-bottom: $footer-mobile-height;
   @include media-breakpoint-up(lg) {
-    margin-bottom: $footer-height;
+    padding-bottom: $footer-height;
   }
 }
 

--- a/templates/v2/pages/history.jinja2
+++ b/templates/v2/pages/history.jinja2
@@ -1,6 +1,6 @@
 {% extends "v2/layouts/inner.jinja2" %}
 
-{% block body_attrs %}data-init-sections="scrollspy" class="position:relative"{% endblock body_attrs %}
+{% block body_attrs %}data-init-sections="scrollspy" style="position:relative"{% endblock body_attrs %}
 
 {% block content %}
     <div class="container page-content">


### PR DESCRIPTION
Нашел баг, для `body` со scrollspy нужно `position: relative` это меняет положение футера
![image](https://user-images.githubusercontent.com/8073736/111155389-74c38200-85a5-11eb-985f-408aec17ff0c.png)
