### PR TITLE
refactor: improve typography

### DIFF
--- a/src/v2/scss/_variables.scss
+++ b/src/v2/scss/_variables.scss
@@ -245,8 +245,6 @@ $h1-font-size:                $font-size-base * 3 !default;
 $h2-font-size:                $font-size-base * 2.25 !default;
 $h3-font-size:                $font-size-base * 1.5 !default;
 $h4-font-size:                $font-size-content-base;
-$h5-font-size:                $font-size-base !default;
-$h6-font-size:                $font-size-base !default;
 
 $text-muted:                  $gray-dark;
 

--- a/src/v2/scss/components/_buttons.scss
+++ b/src/v2/scss/components/_buttons.scss
@@ -119,7 +119,7 @@ $button-fill: solid;
 
 
   &._big {
-    @include button-size(spacer("3x"), spacer("6x"), $font-size-content-base, calculate-input-line-height(56px, spacer("3x")), $btn-border-radius);
+    @include button-size(spacer("3x"), spacer("6x"), $font-size-lg, calculate-input-line-height(56px, spacer("3x")), $btn-border-radius);
     text-transform: uppercase;
     letter-spacing: 2px;
   }

--- a/src/v2/scss/components/_typography.scss
+++ b/src/v2/scss/components/_typography.scss
@@ -1,6 +1,6 @@
 $headings-font-family: inherit !default;
-$headings-font-weight: $font-weight-normal;
-$headings-line-height: 1.2;
+$headings-font-weight: $font-weight-bold;
+$headings-line-height: 1.1;
 $headings-color: inherit !default;
 
 $blockquote-small-color: $gray-disabled;
@@ -20,14 +20,10 @@ h1,
 h2,
 h3,
 h4,
-h5,
-h6,
 .h1,
 .h2,
 .h3,
-.h4,
-.h5,
-.h6 {
+.h4 {
   display: block;
   margin-bottom: spacer("4x");
   font-family: $headings-font-family;
@@ -45,20 +41,18 @@ h1,
   font-size: $h1-font-size;
   margin-bottom: spacer("6x");
   letter-spacing: -.04rem;
-  font-weight: $font-weight-light;
   @include media-breakpoint-down(md) {
-    font-size: 1.75rem;
+    font-size: 2rem;
   }
 }
 
 h2,
 .h2 {
   font-size: $h2-font-size;
-  font-weight: $font-weight-light;
   margin-bottom: spacer("4x");
   letter-spacing: -.04rem;
   @include media-breakpoint-down(md) {
-    font-size: 1.5rem;
+    font-size: 1.75rem;
   }
 }
 
@@ -66,7 +60,7 @@ h3,
 .h3 {
   font-size: $h3-font-size;
   @include media-breakpoint-down(md) {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
   }
 }
 
@@ -75,14 +69,22 @@ h4,
   font-size: $h4-font-size;
 }
 
-h5,
-.h5 {
-  font-size: $h5-font-size;
-}
+p {
+  &._big {
+    font-size: $font-size-lg;
+  }
 
-h6,
-.h6 {
-  font-size: $h6-font-size;
+  &._small {
+    font-size: $font-size-sm;
+  }
+
+  &._extra-small {
+    font-size: $font-size-extra-sm;
+  }
+
+  &._pale {
+    color: $gray-dark;
+  }
 }
 
 // Blockquotes

--- a/templates/v2/layouts/inner.jinja2
+++ b/templates/v2/layouts/inner.jinja2
@@ -11,7 +11,7 @@
 
     <link rel="shortcut icon" type="image/png" href="{{ static("v2/img/favicon.png") }}">
     <link href="{{ static("v2/dist/css/main.css") }}" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Fira+Sans:300,400,600&amp;subset=cyrillic" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap" rel="stylesheet">
 
     {% block stylesheets %} {% endblock stylesheets %}
 


### PR DESCRIPTION
* Удалил неиспользуемые стили `h5`, `h6`
* **Жирное** начертание для заголовков + немного увеличил кегль для мобильной версии
* Курсивное начертание для _italic_
* Утилиты `._big`, `._small`, `._extra-small`, _._pale_ для более гибкой работы с текстом
![image](https://user-images.githubusercontent.com/8073736/124476878-0a308f00-ddac-11eb-9d23-75e8b9193d8b.png)
