### PR TITLE
refactor: replace asterisk style

### DIFF
--- a/src/v2/scss/components/_forms/_survey.scss
+++ b/src/v2/scss/components/_forms/_survey.scss
@@ -23,11 +23,6 @@
     @extend .h3;
     font-weight: $font-weight-normal;
     margin-bottom: spacer("4x");
-
-    .asterisk {
-      font-weight: $font-weight-light;
-      color: $red;
-    }
   }
 }
 

--- a/src/v2/scss/components/_typography.scss
+++ b/src/v2/scss/components/_typography.scss
@@ -136,3 +136,8 @@ code {
 mark {
   background-color: $teal;
 }
+
+.asterisk {
+  font-weight: $font-weight-light;
+  color: $red;
+}


### PR DESCRIPTION
Стиль обязательного поля `*` нужно сделать общим, сейчас он только для полей отчета.